### PR TITLE
feat(telemetry): ship-counter ingest + hero counter

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,0 +1,24 @@
+import { count } from 'drizzle-orm';
+
+import { db } from '@/lib/db';
+import { shipEvents } from '@/drizzle/schema/schema';
+
+/**
+ * Public aggregate for the hero counter. Cached at the edge so the hero never
+ * hits the database on every render.
+ */
+export const runtime = 'edge';
+
+export async function GET(): Promise<Response> {
+  let shipped = 0;
+  try {
+    const [row] = await db.select({ n: count() }).from(shipEvents);
+    shipped = row?.n ?? 0;
+  } catch {
+    // Telemetry table not migrated yet / db unavailable — show 0, never 500.
+  }
+  return Response.json(
+    { shipped },
+    { headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300' } },
+  );
+}

--- a/app/api/telemetry/README.md
+++ b/app/api/telemetry/README.md
@@ -1,0 +1,61 @@
+# Telemetry ingest — activation
+
+Powers the public "🚀 N apps shipped with NextDeploy" hero counter. Reuses the
+existing **Neon Postgres + Drizzle** setup (`@/lib/db`) — no new database.
+
+Files:
+
+- `route.ts` — `POST /api/telemetry`: Ed25519-verifies and records ship events.
+- `../stats/route.ts` — `GET /api/stats`: cached `{ shipped }` count for the hero.
+- `../../../components/sections/ship-count.tsx` — drop-in `<ShipCount />`.
+- table `ship_events` added to `drizzle/schema/schema.ts`.
+
+The ingest returns `503 telemetry not configured` until `TELEMETRY_PUBLIC_KEY`
+is set, so merging this is safe.
+
+## 1. Migrate the new table
+
+```bash
+yarn drizzle:generate     # creates the ship_events migration
+yarn drizzle:migrate      # drizzle-kit push to the DB in drizzle.config.ts
+```
+
+(For prod, run the generated migration against your Neon database.)
+
+## 2. Set the public key
+
+It's the Ed25519 **public** key from the nextdeploy keypair — safe to expose.
+Add to the deployment env (and `.env.local` for dev):
+
+```
+TELEMETRY_PUBLIC_KEY=s5H7U8HbMsxMGGPoIKnSg0zMq3y5W2LPjS9VnoimNxU=
+```
+
+> The matching **private** key is a GitHub Actions secret (`TELEMETRY_SIGNING_KEY`)
+> in the **nextdeploy** repo — only official release binaries can sign events.
+
+## 3. Wire the counter into the hero
+
+`<ShipCount />` is self-contained (fetches `/api/stats`, animates a count-up).
+Drop it into `components/sections/hero-landing.tsx`:
+
+```tsx
+import { ShipCount } from '@/components/sections/ship-count';
+// ...
+<ShipCount className="text-sm text-muted-foreground" />
+```
+
+## 4. Add a rate-limit rule
+
+A Cloudflare Rate Limiting rule on `/api/telemetry` (e.g. 30 req/min/IP) backstops
+volume. Signature verification stops forgery; rate limiting caps a valid build
+being looped.
+
+## Verify
+
+With a signed nextdeploy release live, run `nextdeploy ship` once and confirm a
+row lands (`select count(*) from ship_events`) and the hero ticks up.
+
+> Threat model is best-effort — see nextdeploy `shared/telemetry/README.md`. The
+> signature stops scripted spoofing; it is not unbreakable against someone who
+> extracts the key from the public CLI binary.

--- a/app/api/telemetry/route.ts
+++ b/app/api/telemetry/route.ts
@@ -1,0 +1,88 @@
+import { db } from '@/lib/db';
+import { shipEvents } from '@/drizzle/schema/schema';
+
+/**
+ * Anonymous "apps shipped" telemetry ingest.
+ *
+ * The nextdeploy CLI POSTs one event on a successful `nextdeploy ship`. Official
+ * release binaries Ed25519-sign each event; this endpoint verifies the
+ * signature so a random `curl` cannot inflate the counter. Payload + canonical
+ * signing format are documented in nextdeploy → shared/telemetry/README.md.
+ *
+ * Runs on the edge runtime so the shared db client uses Neon's HTTP driver
+ * (the only one that works on the Worker — see lib/db.ts).
+ */
+export const runtime = 'edge';
+
+const TARGETS = new Set(['vps', 'aws', 'cloudflare', 'other']);
+const MAX_SKEW_SECONDS = 10 * 60;
+const SIG_PREFIX = 'ed25519=';
+
+const b64 = (s: string) => Uint8Array.from(atob(s), (c) => c.charCodeAt(0));
+
+let cachedKey: CryptoKey | null = null;
+async function publicKey(raw: string): Promise<CryptoKey> {
+  if (!cachedKey) {
+    cachedKey = await crypto.subtle.importKey('raw', b64(raw), { name: 'Ed25519' }, false, ['verify']);
+  }
+  return cachedKey;
+}
+
+export async function POST(req: Request): Promise<Response> {
+  const pub = process.env.TELEMETRY_PUBLIC_KEY;
+  if (!pub) return new Response('telemetry not configured', { status: 503 });
+
+  let ev: Record<string, unknown>;
+  try {
+    ev = await req.json();
+  } catch {
+    return new Response('bad json', { status: 400 });
+  }
+
+  // 1. Shape — reject anything off-spec.
+  if (
+    ev.event !== 'ship.success' ||
+    typeof ev.target !== 'string' || !TARGETS.has(ev.target) ||
+    typeof ev.id !== 'string' || typeof ev.nonce !== 'string' ||
+    typeof ev.version !== 'string' || typeof ev.ts !== 'number' ||
+    typeof ev.os !== 'string' || typeof ev.arch !== 'string'
+  ) {
+    return new Response('bad shape', { status: 400 });
+  }
+
+  // 2. Freshness — drop stale/replayed events.
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - ev.ts) > MAX_SKEW_SECONDS) {
+    return new Response('stale', { status: 400 });
+  }
+
+  // 3. Signature — the gate against forged "fake deploy" posts.
+  const header = req.headers.get('X-NextDeploy-Signature') ?? '';
+  if (!header.startsWith(SIG_PREFIX)) return new Response('unsigned', { status: 401 });
+  const msg = new TextEncoder().encode(
+    [ev.id, ev.event, ev.target, ev.version, ev.os, ev.arch, ev.ts, ev.nonce].join('|'),
+  );
+  let ok = false;
+  try {
+    ok = await crypto.subtle.verify('Ed25519', await publicKey(pub), b64(header.slice(SIG_PREFIX.length)), msg);
+  } catch {
+    ok = false;
+  }
+  if (!ok) return new Response('bad signature', { status: 401 });
+
+  // 4. Idempotent insert — the nonce PK dedups replays of a valid event.
+  await db
+    .insert(shipEvents)
+    .values({
+      nonce: ev.nonce,
+      installId: ev.id,
+      target: ev.target,
+      version: ev.version,
+      os: ev.os,
+      arch: ev.arch,
+      eventTs: ev.ts,
+    })
+    .onConflictDoNothing();
+
+  return new Response(null, { status: 204 });
+}

--- a/components/sections/ship-count.tsx
+++ b/components/sections/ship-count.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Drop-in "apps shipped" counter for the hero. Self-contained: fetches
+ * /api/stats and animates a count-up. Renders nothing until the value loads, so
+ * it never causes layout jank or an SSR/CSR mismatch.
+ *
+ * Usage (anywhere, incl. inside the client hero):
+ *   <ShipCount className="text-sm text-muted-foreground" />
+ */
+export function ShipCount({ className }: { className?: string }) {
+  const [display, setDisplay] = useState<number | null>(null);
+  const raf = useRef<number | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/stats")
+      .then((r) => r.json())
+      .then((d: { shipped?: number }) => {
+        if (!alive) return;
+        const target = d.shipped ?? 0;
+        const start = performance.now();
+        const tick = (t: number) => {
+          const p = Math.min(1, (t - start) / 800);
+          setDisplay(Math.round(target * (1 - Math.pow(1 - p, 3)))); // easeOutCubic
+          if (p < 1) raf.current = requestAnimationFrame(tick);
+        };
+        raf.current = requestAnimationFrame(tick);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+      if (raf.current) cancelAnimationFrame(raf.current);
+    };
+  }, []);
+
+  if (display === null) return null;
+  return (
+    <p className={className}>
+      🚀 {display.toLocaleString()} apps shipped with NextDeploy
+    </p>
+  );
+}

--- a/drizzle/schema/schema.ts
+++ b/drizzle/schema/schema.ts
@@ -884,3 +884,22 @@ export const auditLogRelations = relations(auditLog, ({ one }) => ({
     references: [project.id],
   }),
 }));
+
+// ====================== TELEMETRY ======================
+// Anonymous "apps shipped" events from the nextdeploy CLI. One row per
+// successful, Ed25519-verified ship. No identifying data — see the ingest route
+// (app/api/telemetry/route.ts) and nextdeploy shared/telemetry/README.md.
+export const shipEvents = pgTable(
+  'ship_events',
+  {
+    nonce: text('nonce').primaryKey(), // per-event → idempotent dedup of replays
+    installId: text('install_id').notNull(), // anonymous per-install id
+    target: text('target').notNull(), // vps | aws | cloudflare | other
+    version: text('version').notNull(),
+    os: text('os'),
+    arch: text('arch'),
+    eventTs: integer('event_ts').notNull(), // client unix seconds
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+  },
+  (table) => [index('idx_ship_events_created').on(table.createdAt)],
+);


### PR DESCRIPTION
Wires the nextdeploy CLI's anonymous "apps shipped" telemetry into the site → a "🚀 N apps shipped with NextDeploy" hero counter.

## What's here
- **`POST /api/telemetry`** — Ed25519-verifies each event (Web Crypto, edge runtime) against `TELEMETRY_PUBLIC_KEY`, checks timestamp freshness, dedups by `nonce`, records it. Unsigned/forged/stale posts are rejected, so a random `curl` can't inflate the counter.
- **`GET /api/stats`** — cached `{ shipped }` count.
- **`ship_events`** table appended to `drizzle/schema/schema.ts` — **reuses the existing Neon Postgres via `@/lib/db`** (no new DB; works on the Worker via the Neon HTTP driver).
- **`<ShipCount />`** — self-contained, animated hero counter (fetches `/api/stats`).

## Design notes
I started from the integration doc's D1 plan but corrected course after reading the repo: `@opennextjs/cloudflare` isn't a dependency and the app already uses **Neon + Drizzle via `process.env`**, which runs on the edge — so reusing it is cleaner than bolting on D1. Ed25519 verification uses **Web Crypto natively** (no `@noble/ed25519` dep).

I did **not** touch `hero-landing.tsx` or `wrangler.jsonc` (both in your uncommitted working tree) — `<ShipCount />` is a drop-in you place where you want.

## Activation (inert until then — returns 503)
See `app/api/telemetry/README.md`:
1. `yarn drizzle:generate && yarn drizzle:migrate` (creates `ship_events`)
2. Set `TELEMETRY_PUBLIC_KEY=s5H7U8HbMsxMGGPoIKnSg0zMq3y5W2LPjS9VnoimNxU=`
3. Drop `<ShipCount />` into the hero
4. Add a CF rate-limit rule on `/api/telemetry`

## Verification
New files **typecheck clean** (`yarn tsc --noEmit`). Built in an isolated git worktree so your uncommitted changes were never touched.

> Note: signing's threat model is best-effort (nextdeploy `shared/telemetry/README.md`) — stops scripted spoofing, not key extraction from the public binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)